### PR TITLE
unix: fixed build on freebsd

### DIFF
--- a/src/platform-unix.cc
+++ b/src/platform-unix.cc
@@ -2,6 +2,7 @@
 #include "netroute.h"
 
 #include <errno.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
@@ -50,10 +51,12 @@ Handle<Value> GetInfo(int family) {
     rt_msghdr* msg = reinterpret_cast<rt_msghdr*>(current);
 
     // Skip cloned routes
+#ifdef RTF_WASCLONED
     if (msg->rtm_flags & RTF_WASCLONED) {
       current += msg->rtm_msglen;
       continue;
     }
+#endif
 
     Local<Object> info = Object::New();
 


### PR DESCRIPTION
Building on FreeBSD 10 (with clang), the RTF_WASCLONED constant was removed in FreeBSD 8, also complained about malloc and stuff being undefined. Not sure if this is the best solution but at least it builds.
