### PR TITLE
Refactored param name to be strict compliant

### DIFF
--- a/lib/netroute.js
+++ b/lib/netroute.js
@@ -2,14 +2,14 @@ var bindings = require('bindings');
 
 exports.getInfo = bindings('netroute').getInfo;
 
-exports.getGateway = function getGateway(interface) {
+exports.getGateway = function getGateway(iface) {
   var info = exports.getInfo(),
       def;
 
   // Search in IPv4 list
   def = info.IPv4.filter(function(route) {
     return route.destination === '0.0.0.0' &&
-           (!interface || route.interface === interface);
+           (!iface || route.interface === iface);
   });
 
   if (def.length !== 0) return def[0].gateway;
@@ -17,7 +17,7 @@ exports.getGateway = function getGateway(interface) {
   // And in IPv6 list
   def = info.IPv6.filter(function(route) {
     return route.destination === '::0' &&
-           (!interface || route.interface === interface);
+           (!iface || route.interface === iface);
   });
 
   return def[0] ? def[0].gateway : null;


### PR DESCRIPTION
When using `use strict;` mode with transpiler such as `babel`, the following error is given
```
ERROR in ./node_modules/netroute/lib/netroute.js
Module build failed: SyntaxError: interface is a reserved word in strict mode (12:13)

  10 |   def = info.IPv4.filter(function(route) {
  11 |     return route.destination === '0.0.0.0' &&
> 12 |            (!interface || route.interface === interface);
     |              ^
  13 |   });
  14 | 
  15 |   if (def.length !== 0) return def[0].gateway;
```